### PR TITLE
Fix kubenetes manifests, add dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# pl7ofit_platform
-pl7ofit Platform repository
+Проделанная работа:
+  1. Написал Dockerfile с веб-сервером nginx, собрал образ, запушил в dockerhub
+  2. Написал манифест web-pod.yaml с init контейнером для подтягивания статики в общий mountPath /app
+  3. Собрал образ microservices-demo и запушил в dockerhub
+  4. Сгенерировал ad-hoc коммандой манифест frontend-pod.yaml для сервиса microservices-demo
+  5. Создал исправленный frontend-pod-healthy.yaml на основе frontend-pod.yaml
+  6. Запушил ДЗ в репу
+
+q: Разберитесь почему все pod в namespace kube-system восстановились после удаления. Укажите причину в описании PR
+
+a: Потому что они были восстановлены deployment'ом

--- a/frontend-pod.yaml
+++ b/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: pl7ofit/otus_lessons:l1_frontend
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: pl7ofit/otus_lessons:l1_frontend
+    name: frontend
+    resources: {}
+    env:
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "productcatalogservice:3550"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "currencyservice:7000"
+    - name: CART_SERVICE_ADDR
+      value: "cartservice:7070"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "recommendationservice:8080"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "shippingservice:50051"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "checkoutservice:5050"
+    - name: AD_SERVICE_ADDR
+      value: "adservice:9555"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1 # Версия API
+kind: Pod # Объект, который создаем
+metadata:
+  name: web # Название Pod
+  labels: # Метки в формате key: value
+    lesson-number: "1"
+spec: # Описание Pod
+  volumes:
+  - name: app
+    emptyDir: {}
+  containers: # Описание контейнеров внутри Pod
+    - name: web # Название контейнера
+      image: pl7ofit/otus_lessons:l1_nginx # Образ из которого создается контейнер
+      volumeMounts:
+      - name: app
+        mountPath: /app
+  initContainers:
+    - name: init
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+      - name: app
+        mountPath: /app
+

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,28 @@
+FROM nginx:alpine
+RUN printf '\n\
+          worker_processes  auto;\n\
+          error_log  /dev/stderr;\n\
+          pid        /tmp/nginx.pid;\n\
+          events {worker_connections  1024;}\n\
+          http \n\
+          {\n\
+            access_log  /dev/stdout;\n\
+            sendfile        on;\n\
+            keepalive_timeout  65;\n\
+            server{\n\
+              listen 8000;\n\
+              location / \n\
+              {\n\
+                root /app;\n\
+              }\n\
+            }\n\
+          }\n\
+          ' > /etc/nginx/nginx_custom.conf
+RUN mkdir /app && \
+    adduser -D -H -s /bin/false -u 1001 alpine && \
+    chown -R alpine:alpine /app && \
+    chown -R alpine:alpine /var/cache/nginx/
+USER alpine
+EXPOSE 8000
+ENTRYPOINT ["nginx", "-c", "/etc/nginx/nginx_custom.conf", "-g", "daemon off;"]
+


### PR DESCRIPTION
Проделанная работа:
  1. Написал Dockerfile с веб-сервером nginx, собрал образ, запушил в dockerhub
  2. Написал манифест web-pod.yaml с init контейнером для подтягивания статики в общий mountPath /app
  3. Собрал образ microservices-demo и запушил в dockerhub
  4. Сгенерировал ad-hoc коммандой манифест frontend-pod.yaml для сервиса microservices-demo
  5. Создал исправленный frontend-pod-healthy.yaml на основе frontend-pod.yaml
  6. Запушил ДЗ в репу

  q: Разберитесь почему все pod в namespace kube-system восстановились после удаления. Укажите причину в описании PR
  a: Потому что они были восстановлены deployment'ом
